### PR TITLE
docs: add Deploy to Zeabur button in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Before you begin, ensure you have the following software installed:
 
     ```
 
+### Deploy
+
+You can click on the button below to deploy the bot to Zeabur.
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/Z8668N)
+
 ### Reference
 
 https://github.com/yihong0618/tg_bot_collections


### PR DESCRIPTION
Deploy:
<img width="1801" alt="image" src="https://github.com/kenwoodjw/TG_GEMINI_BOT/assets/63531512/91848c43-b47c-4ed8-89ed-685d13b5e785">

Deploy Result:
<img width="1512" alt="Snipaste_2023-12-26_15-55-39" src="https://github.com/kenwoodjw/TG_GEMINI_BOT/assets/63531512/bed833f2-e68d-405c-8bd3-39d69f95921b">
<img width="1801" alt="Snipaste_2023-12-26_15-55-45" src="https://github.com/kenwoodjw/TG_GEMINI_BOT/assets/63531512/1c68415d-987b-47a9-9394-90213a7a3020">
